### PR TITLE
Update class.gettext.php 

### DIFF
--- a/lib/G/classes/class.gettext.php
+++ b/lib/G/classes/class.gettext.php
@@ -335,7 +335,7 @@ class Gettext {
 		}
 		// Detect if callable function has been already created
 		if(!array_key_exists('callable', $this->translation_plural)) {
-			$this->translation_plural['callable'] = create_function('$n', $this->translation_plural['function']);
+			$this->translation_plural['callable'] = function($n) { return eval($this->translation_plural['function']); };
 		}
 		return call_user_func($this->translation_plural['callable'], $count);
 	}


### PR DESCRIPTION
This function has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged.

The php documentation recommends using anonymous functions. Given that $this->translation_plural['function'] looks like it is a string, you should consider a rewrite.