### PR TITLE
Fatal error: app/install is outdated. You need to re-upload app/insta…

### DIFF
--- a/app/install/installer.php
+++ b/app/install/installer.php
@@ -287,6 +287,7 @@ try {
             'image_lock_nsfw_editing' => 0,
         ],
         '1.4.0' => null,
+        '1.4.1' => null,
     ];
     // Settings that must be renamed from NAME to NEW NAME and DELETE old NAME
     $settings_rename = [];


### PR DESCRIPTION
Getting Fetal error while upgrade from 1.4.0 to 1.4.1
Fatal error: app/install is outdated. You need to re-upload app/install folder with the one from Chevereto 1.4.1